### PR TITLE
Fix for Declaration of qbank_bulkxmlexport\plugin_feature::get_bulk_actions() error

### DIFF
--- a/classes/plugin_feature.php
+++ b/classes/plugin_feature.php
@@ -15,7 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace qbank_bulkxmlexport;
+use core_question\local\bank\bulk_action_base;
 use core_question\local\bank\plugin_features_base;
+use core_question\local\bank\view;
 
 /**
  * Class plugin_feature is the entrypoint for the features.
@@ -31,7 +33,8 @@ class plugin_feature extends plugin_features_base {
      *
      * @return bulk_action_base[]
      */
-    public function get_bulk_actions(): array {
+    #[\Override]
+    public function get_bulk_actions(?view $qbank = null): array {
         return [
             new xmlexport(),
         ];


### PR DESCRIPTION
Moodle 4.4.6+ caused this issue.  Made the plugin_feature file look like other bulk action files.

PHP Fatal error:  Declaration of qbank_bulkxmlexport\plugin_feature::get_bulk_actions(): array must be compatible with core_question\local\bank\plugin_features_base::get_bulk_actions(?core_question\local\bank\view $qbank = null) in C:\laragon\www\moodle44\question\bank\bulkxmlexport\classes\plugin_feature.php on line 34